### PR TITLE
Updated with link to Swift SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ If you see a link or project here that is no longer maintained or is not a good 
 * [Ruby SDK](https://github.com/stellar/ruby-stellar-sdk);
 * [Python SDK](https://github.com/StellarCN/py-stellar-base);
 * [C++ SDK](https://github.com/bnogalm/StellarQtSDK) - C++ SDK by bnogalm;
+* [Swift SDK](https://github.com/kinfoundation/StellarKit);
 
 ### Code
 


### PR DESCRIPTION
The Kin Foundation is maintaining a Swift SDK which is great for iOS and MacOS developers to keep up with.